### PR TITLE
fix: Dockerfile downloads FAISS index from GitHub Release

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install system deps for psycopg2-binary
+# Install system deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libpq-dev \
+    libpq-dev curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
@@ -14,9 +14,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
-# FAISS index: copy from local build context if present,
-# otherwise must be mounted or built at runtime.
-# To build: place index_kms/ in backend/ before `docker build`.
+# Download FAISS index from GitHub Release
+RUN mkdir -p index_kms && \
+    curl -sL https://github.com/asfalanoij/NIST_chatbot/releases/download/v2.0.0/index.faiss -o index_kms/index.faiss && \
+    curl -sL https://github.com/asfalanoij/NIST_chatbot/releases/download/v2.0.0/index.pkl -o index_kms/index.pkl
 
 EXPOSE ${PORT:-5050}
 


### PR DESCRIPTION
## Summary
- Dockerfile now downloads FAISS index from v2.0.0 GitHub Release at build time
- Index too large for git (21MB) — release assets solve this cleanly

## Test plan
- [x] CI passes on dev
- [ ] Render Docker build downloads index successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)