### PR TITLE
fix: point VITE_API_URL to live Render backend

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -48,7 +48,9 @@ services:
         destination: /index.html
     envVars:
       - key: VITE_API_URL
-        value: https://80053-api.rudyprasetiya.com
+        value: https://nist-chatbot-api.onrender.com
+      - key: VITE_API_KEY
+        sync: false
 
 databases:
   - name: nist-chatbot-db


### PR DESCRIPTION
## Summary
- `VITE_API_URL` was set to `https://80053-api.rudyprasetiya.com` (custom domain, not yet configured) — frontend built with wrong URL causing all API calls to fail
- Fixed to `https://nist-chatbot-api.onrender.com` (the live backend)
- Added `VITE_API_KEY` (sync:false) so the API key can be manually set in Render dashboard to match the backend's generated `API_KEY`

## After merging
1. Render will redeploy `nist-chatbot-frontend` automatically
2. **Manual step in Render dashboard**: copy `API_KEY` value from `nist-chatbot-api` service → paste it as `VITE_API_KEY` in `nist-chatbot-frontend` service → redeploy frontend
3. Chat should work end-to-end

## Test plan
- [ ] Frontend loads at https://nist-chatbot-frontend.onrender.com
- [ ] Health indicator shows "Gemini" (not "Offline")
- [ ] Send a test question — response received, no connection error

🤖 Generated with [Claude Code](https://claude.com/claude-code)